### PR TITLE
dry run option

### DIFF
--- a/lib/components/services/audit/generate-trigger-statement.js
+++ b/lib/components/services/audit/generate-trigger-statement.js
@@ -17,6 +17,6 @@ module.exports = function generateTriggerStatement (options) {
       return `DROP TRIGGER IF EXISTS ${namespace}_${name}_auditor
       ON ${namespace}.${name};`
     default:
-      return ``
+      return ''
   }
 }

--- a/lib/components/services/storage/generate-upsert-statement.js
+++ b/lib/components/services/storage/generate-upsert-statement.js
@@ -11,7 +11,7 @@ const _ = require('lodash')
 module.exports = function generateUpsertStatement (model, object) {
   const columnCount = object.propertyNames.length
   const rowCount = object.data.length
-  let columnNames = []
+  const columnNames = []
 
   for (const pn of object.propertyNames) {
     columnNames.push(_.snakeCase(pn))

--- a/lib/components/services/storage/index.js
+++ b/lib/components/services/storage/index.js
@@ -79,7 +79,7 @@ class PostgresqlStorageService {
   async _generateSequences (sequences, messages) {
     infoMessage(messages, 'Loading sequences:')
     for (const [id, value] of Object.entries(sequences || {})) {
-      if (value.hasOwnProperty('startWith')) {
+      if (value.startWith) {
         detailMessage(messages, id)
         const sql = `CREATE SEQUENCE IF NOT EXISTS ${_.snakeCase(value.namespace)}.${_.snakeCase(value.id)} START WITH ${value.startWith};`
         await this.client.query(sql)
@@ -105,12 +105,12 @@ class PostgresqlStorageService {
     const updateStatements = generateUpdateStatements(currentDbStructure, expectedDbStructure)
 
     if (createStatements.length) {
-      infoMessage(messages, `Creating new database objects`)
+      infoMessage(messages, 'Creating new database objects')
       await this.client.run(createStatements)
     }
 
     if (updateStatements.length) {
-      infoMessage(messages, `Altering existing database objects`)
+      infoMessage(messages, 'Altering existing database objects')
       try {
         this.client.run(updateStatements)
       } catch (err) {
@@ -189,8 +189,8 @@ class PostgresqlStorageService {
 
             _this.client.run(
               [{
-                'sql': sql,
-                'params': params
+                sql: sql,
+                params: params
               }],
               function (err) {
                 if (err) {
@@ -293,8 +293,8 @@ function generateStatements (currentDbStructure, expectedDbStructure, options) {
 
 function statementTransform (statement) {
   return {
-    'sql': statement,
-    'params': []
+    sql: statement,
+    params: []
   }
 }
 

--- a/lib/components/state-resources/audit-trail/index.js
+++ b/lib/components/state-resources/audit-trail/index.js
@@ -3,7 +3,7 @@ const DateTime = require('luxon').DateTime
 
 class AuditTrail {
   init (resourceConfig, env, callback) {
-    this.auditLog = env.bootedServices.storage.models['tymly_rewind']
+    this.auditLog = env.bootedServices.storage.models.tymly_rewind
     this.models = env.blueprintComponents.models
 
     callback(null)

--- a/lib/components/state-resources/exporting-csv-delta-file/index.js
+++ b/lib/components/state-resources/exporting-csv-delta-file/index.js
@@ -35,7 +35,8 @@ class ExportingCsvDeltaFile {
           filterFunction: this.filterFunction,
           createdColumnName: this.createdColumnName,
           modifiedColumnName: this.modifiedColumnName,
-          csvExtracts: this.csvExtracts
+          csvExtracts: this.csvExtracts,
+          dryrun: event.dryrun
         }
       )
 

--- a/lib/components/state-resources/importing-csv-files/multicopy.js
+++ b/lib/components/state-resources/importing-csv-files/multicopy.js
@@ -31,7 +31,7 @@ function getSchemaTablePairs (dirs) {
 
   const schemas = getDirs(dirs)
   schemas.forEach(schema => {
-    let tables = getDirs(path.resolve(dirs, schema))
+    const tables = getDirs(path.resolve(dirs, schema))
     tables.forEach(table => schemaTablePairs.push([schema, table]))
   })
 

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "lodash": "4.17.15",
     "luxon": "1.17.2",
     "@wmfs/hl-pg-client": "1.13.0",
-    "@wmfs/pg-delta-file": "1.32.0",
+    "@wmfs/pg-delta-file": "1.32.1",
     "@wmfs/pg-diff-sync": "1.15.0",
     "@wmfs/pg-info": "1.13.0",
     "@wmfs/pg-model": "1.17.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "debug": "4.1.1",
     "dottie": "2.0.1",
     "lodash": "4.17.15",
-    "luxon": "1.17.2",
+    "luxon": "1.19.3",
     "@wmfs/hl-pg-client": "1.13.0",
     "@wmfs/pg-delta-file": "1.32.1",
     "@wmfs/pg-diff-sync": "1.15.0",
@@ -39,17 +39,17 @@
   "devDependencies": {
     "chai": "4.2.0",
     "chai-subset": "1.6.0",
-    "codecov": "3.5.0",
+    "codecov": "3.6.1",
     "conventional-changelog-metahub": "2.0.2",
     "cz-conventional-changelog": "3.0.2",
-    "mocha": "6.2.0",
+    "mocha": "6.2.1",
     "nyc": "14.1.1",
     "rimraf": "3.0.0",
     "semantic-release": "15.13.24",
-    "standard": "12.0.1",
+    "standard": "14.3.1",
     "@semantic-release/changelog": "3.0.4",
     "@semantic-release/git": "7.0.16",
-    "@wmfs/tymly": "1.98.0"
+    "@wmfs/tymly": "1.98.1"
   },
   "scripts": {
     "lint": "standard",

--- a/test/audit-spec.js
+++ b/test/audit-spec.js
@@ -42,33 +42,33 @@ describe('Audit service tests', function () {
   })
 
   it('insert a dog to animal-with-age', async () => {
-    await models['tymlyTest_animalWithAge'].create({
+    await models.tymlyTest_animalWithAge.create({
       animal: 'dog',
       colour: 'brown'
     })
   })
 
   it('check the dog is brown', async () => {
-    const res = await models['tymlyTest_animalWithAge'].find({})
+    const res = await models.tymlyTest_animalWithAge.find({})
 
     expect(res[0].colour).to.eql('brown')
   })
 
   it('update the dog\'s colour to black', async () => {
-    await models['tymlyTest_animalWithAge'].update({
+    await models.tymlyTest_animalWithAge.update({
       animal: 'dog',
       colour: 'black'
     }, {})
   })
 
   it('confirm dog is black', async () => {
-    const res = await models['tymlyTest_animalWithAge'].find({})
+    const res = await models.tymlyTest_animalWithAge.find({})
 
     expect(res[0].colour).to.eql('black')
   })
 
   it('check the change has been documented in tymly.rewind', async () => {
-    const res = await models['tymly_rewind'].find({
+    const res = await models.tymly_rewind.find({
       where: {
         modelName: { equals: 'tymly_test.animal_with_age' }
       }
@@ -82,33 +82,33 @@ describe('Audit service tests', function () {
   })
 
   it('insert a cat to animal-with-year', async () => {
-    await models['tymlyTest_animalWithYear'].create({
+    await models.tymlyTest_animalWithYear.create({
       animal: 'cat',
       colour: 'ginger'
     })
   })
 
   it('check the cat is ginger', async () => {
-    const res = await models['tymlyTest_animalWithYear'].find({})
+    const res = await models.tymlyTest_animalWithYear.find({})
 
     expect(res[0].colour).to.eql('ginger')
   })
 
   it('update the cat update the cat\'s colour to white', async () => {
-    await models['tymlyTest_animalWithYear'].update({
+    await models.tymlyTest_animalWithYear.update({
       animal: 'cat',
       colour: 'white'
     }, {})
   })
 
   it('check the cat is white', async () => {
-    const res = await models['tymlyTest_animalWithYear'].find({})
+    const res = await models.tymlyTest_animalWithYear.find({})
 
     expect(res[0].colour).to.eql('white')
   })
 
   it('check the change has NOT been documented in tymly.rewind', async () => {
-    const res = await models['tymly_rewind'].find({
+    const res = await models.tymly_rewind.find({
       where: {
         modelName: { equals: 'tymly_test.animal_with_year' }
       }
@@ -118,15 +118,15 @@ describe('Audit service tests', function () {
   })
 
   it('clean up animal-with-age', async () => {
-    await models['tymlyTest_animalWithAge'].destroyById('dog')
+    await models.tymlyTest_animalWithAge.destroyById('dog')
   })
 
   it('clean up animal-with-year', async () => {
-    await models['tymlyTest_animalWithYear'].destroyById('cat')
+    await models.tymlyTest_animalWithYear.destroyById('cat')
   })
 
   it('clean up rewind', async () => {
-    await models['tymly_rewind'].destroyById(rewindIdToDestroy)
+    await models.tymly_rewind.destroyById(rewindIdToDestroy)
   })
 
   it('uninstall test schemas', async () => {

--- a/test/basic-tests.js
+++ b/test/basic-tests.js
@@ -221,14 +221,14 @@ describe('PostgreSQL storage tests', function () {
   it('should ensure the categories service (which has JSONB columns) still works', function () {
     expect(Object.keys(categoryService.categories).includes('gas')).to.eql(true)
     expect(Object.keys(categoryService.categories).includes('terrestrial')).to.eql(true)
-    expect(categoryService.categories['gas']).to.eql({
+    expect(categoryService.categories.gas).to.eql({
       category: 'gas',
       label: 'Gas',
       styling: {
         'background-color': '#80C342'
       }
     })
-    expect(categoryService.categories['terrestrial']).to.eql({
+    expect(categoryService.categories.terrestrial).to.eql({
       category: 'terrestrial',
       label: 'terrestrial',
       styling: {

--- a/test/findById-state-resource-spec.js
+++ b/test/findById-state-resource-spec.js
@@ -67,7 +67,7 @@ describe('FindById State Resource', function () {
 
   it('find by composite key, passing array', async () => {
     const executionDescription = await statebox.startExecution(
-      { key: [ 'Billy', 'Dog' ] },
+      { key: ['Billy', 'Dog'] },
       COMPOSITE_KEY,
       {
         sendResponse: 'COMPLETE'

--- a/test/multicopy-state-tests.js
+++ b/test/multicopy-state-tests.js
@@ -14,7 +14,7 @@ describe('Testing functionality as a state-resource', function () {
   let client
   let tymlyService
   let statebox
-  let STATE_MACHINE_NAME = 'foodTest_food_1_0'
+  const STATE_MACHINE_NAME = 'foodTest_food_1_0'
   let executionName
 
   before(function () {

--- a/test/multicopy-test.js
+++ b/test/multicopy-test.js
@@ -12,8 +12,8 @@ const process = require('process')
 describe('Multicopy tests', function () {
   this.timeout(process.env.TIMEOUT || 5000)
 
-  let connectionString = process.env.PG_CONNECTION_STRING
-  let client = new HlPgClient(connectionString)
+  const connectionString = process.env.PG_CONNECTION_STRING
+  const client = new HlPgClient(connectionString)
 
   before(function () {
     if (process.env.PG_CONNECTION_STRING && !/^postgres:\/\/[^:]+:[^@]+@(?:localhost|127\.0\.0\.1).*$/.test(process.env.PG_CONNECTION_STRING)) {

--- a/test/pg-storage-spec.js
+++ b/test/pg-storage-spec.js
@@ -167,10 +167,10 @@ describe('PG storage tests', function () {
           expect(err).to.equal(null)
           expect(doc).to.containSubset(
             {
-              'employeeNo': '3',
-              'firstName': 'Lisa',
-              'lastName': 'Simpson',
-              'age': 8
+              employeeNo: '3',
+              firstName: 'Lisa',
+              lastName: 'Simpson',
+              age: 8
             }
           )
           done()
@@ -204,33 +204,33 @@ describe('PG storage tests', function () {
           expect(doc).to.containSubset(
             [
               {
-                'age': 8,
-                'employeeNo': '3',
-                'firstName': 'Lisa',
-                'lastName': 'Simpson'
+                age: 8,
+                employeeNo: '3',
+                firstName: 'Lisa',
+                lastName: 'Simpson'
               },
               {
-                'age': 10,
-                'employeeNo': '5',
-                'firstName': 'Bart',
-                'lastName': 'Simpson'
+                age: 10,
+                employeeNo: '5',
+                firstName: 'Bart',
+                lastName: 'Simpson'
               },
               {
-                'age': 36,
-                'employeeNo': '4',
-                'firstName': 'Marge',
-                'lastName': 'Simpson'
+                age: 36,
+                employeeNo: '4',
+                firstName: 'Marge',
+                lastName: 'Simpson'
               },
               {
-                'age': 39,
-                'employeeNo': '1',
-                'firstName': 'Homer',
-                'lastName': 'Simpson'
+                age: 39,
+                employeeNo: '1',
+                firstName: 'Homer',
+                lastName: 'Simpson'
               },
               {
-                'employeeNo': '2',
-                'firstName': 'Maggie',
-                'lastName': 'Simpson'
+                employeeNo: '2',
+                firstName: 'Maggie',
+                lastName: 'Simpson'
               }
             ]
           )
@@ -253,10 +253,10 @@ describe('PG storage tests', function () {
           expect(doc).to.containSubset(
             [
               {
-                'age': 10,
-                'employeeNo': '5',
-                'firstName': 'Bart',
-                'lastName': 'Simpson'
+                age: 10,
+                employeeNo: '5',
+                firstName: 'Bart',
+                lastName: 'Simpson'
               }
             ]
           )
@@ -281,16 +281,16 @@ describe('PG storage tests', function () {
           expect(doc).to.containSubset(
             [
               {
-                'employeeNo': '4',
-                'firstName': 'Marge',
-                'lastName': 'Simpson',
-                'age': 36
+                employeeNo: '4',
+                firstName: 'Marge',
+                lastName: 'Simpson',
+                age: 36
               },
               {
-                'employeeNo': '1',
-                'firstName': 'Homer',
-                'lastName': 'Simpson',
-                'age': 39
+                employeeNo: '1',
+                firstName: 'Homer',
+                lastName: 'Simpson',
+                age: 39
               }
             ]
           )
@@ -309,10 +309,10 @@ describe('PG storage tests', function () {
           expect(err).to.equal(null)
           expect(doc).to.containSubset(
             {
-              'age': 10,
-              'employeeNo': '5',
-              'firstName': 'Bart',
-              'lastName': 'Simpson'
+              age: 10,
+              employeeNo: '5',
+              firstName: 'Bart',
+              lastName: 'Simpson'
             }
           )
 
@@ -333,10 +333,10 @@ describe('PG storage tests', function () {
           expect(err).to.equal(null)
           expect(doc).to.containSubset(
             {
-              'age': 39,
-              'employeeNo': '1',
-              'firstName': 'Homer',
-              'lastName': 'Simpson'
+              age: 39,
+              employeeNo: '1',
+              firstName: 'Homer',
+              lastName: 'Simpson'
             }
           )
 
@@ -384,10 +384,10 @@ describe('PG storage tests', function () {
           expect(err).to.equal(null)
           expect(doc).to.containSubset(
             {
-              'employeeNo': '2',
-              'firstName': 'Maggie',
-              'lastName': 'Simpson',
-              'age': 1
+              employeeNo: '2',
+              firstName: 'Maggie',
+              lastName: 'Simpson',
+              age: 1
             }
           )
           done()
@@ -417,9 +417,9 @@ describe('PG storage tests', function () {
           expect(err).to.equal(null)
           expect(doc).to.containSubset(
             {
-              'employeeNo': '2',
-              'firstName': 'Maggie',
-              'lastName': 'Simpson'
+              employeeNo: '2',
+              firstName: 'Maggie',
+              lastName: 'Simpson'
             }
           )
           done()
@@ -529,10 +529,10 @@ describe('PG storage tests', function () {
           expect(err).to.equal(null)
           expect(doc).to.containSubset(
             {
-              'employeeNo': '10',
-              'firstName': 'Abe',
-              'lastName': 'Simpson',
-              'age': 82
+              employeeNo: '10',
+              firstName: 'Abe',
+              lastName: 'Simpson',
+              age: 82
             }
           )
           done()
@@ -563,10 +563,10 @@ describe('PG storage tests', function () {
           expect(err).to.equal(null)
           expect(doc).to.containSubset(
             {
-              'employeeNo': '10',
-              'firstName': 'Abraham',
-              'lastName': 'Simpson',
-              'age': 83
+              employeeNo: '10',
+              firstName: 'Abraham',
+              lastName: 'Simpson',
+              age: 83
             }
           )
           done()
@@ -583,8 +583,8 @@ describe('PG storage tests', function () {
           expect(err).to.equal(null)
           expect(doc).to.containSubset(
             {
-              'name': 'Proxima Centauri',
-              'type': 'Red Dwarf'
+              name: 'Proxima Centauri',
+              type: 'Red Dwarf'
             }
           )
           done()
@@ -671,11 +671,11 @@ describe('PG storage tests', function () {
 
       expect(doc).to.containSubset(
         {
-          'employeeNo': '1000',
-          'firstName': 'James',
-          'lastName': 'Thompson',
-          'age': 39,
-          'createdBy': 'test'
+          employeeNo: '1000',
+          firstName: 'James',
+          lastName: 'Thompson',
+          age: 39,
+          createdBy: 'test'
         }
       )
     })
@@ -703,12 +703,12 @@ describe('PG storage tests', function () {
 
       expect(doc).to.containSubset(
         {
-          'employeeNo': '1000',
-          'firstName': 'Jim',
-          'lastName': 'Thompson',
-          'age': 39,
-          'createdBy': 'test',
-          'modifiedBy': 'modifier'
+          employeeNo: '1000',
+          firstName: 'Jim',
+          lastName: 'Thompson',
+          age: 39,
+          createdBy: 'test',
+          modifiedBy: 'modifier'
         }
       )
     })

--- a/test/restart-fixtures/plugins/cats-plugin/components/states/walking/index.js
+++ b/test/restart-fixtures/plugins/cats-plugin/components/states/walking/index.js
@@ -9,7 +9,7 @@ class Walking {
     const ctx = tymly.ctx
 
     let destination
-    if (data !== undefined && data.hasOwnProperty('destination')) {
+    if (data !== undefined && data.destination) {
       destination = 'to the ' + data.destination
     } else {
       destination = 'somewhere'

--- a/test/state-resource-tests.js
+++ b/test/state-resource-tests.js
@@ -124,15 +124,15 @@ describe('State Resource Tests', function () {
             switch (res.animal) {
               case 'dog':
                 expect(res.colour).to.eql('brown')
-                expect(res['year_born']).to.eql(2011)
+                expect(res.year_born).to.eql(2011)
                 break
               case 'cat':
                 expect(res.colour).to.eql('black')
-                expect(res['year_born']).to.eql(2015)
+                expect(res.year_born).to.eql(2015)
                 break
               case 'mouse':
                 expect(res.colour).to.eql('grey')
-                expect(res['year_born']).to.eql(2014)
+                expect(res.year_born).to.eql(2014)
                 break
             }
           }


### PR DESCRIPTION
Added dryrun option. When set, do everything except create output files. Filters and transformers are applied, counts created, and so on, just nothing ends up on the file system.

Simply pass dryrun flag through to pg-delta-file. Nothing else to do here.

See https://github.com/wmfs/pg-delta-file/pull/175