### PR TITLE
feat: Extend export-csv-delta-file to take a progress callback

### DIFF
--- a/lib/components/state-resources/exporting-csv-delta-file/index.js
+++ b/lib/components/state-resources/exporting-csv-delta-file/index.js
@@ -1,7 +1,8 @@
 /**
  * Created by Aron.Moore on 12/07/2017.
  */
-'use strict'
+const dottie = require('dottie')
+const cloneDeep = require('lodash').cloneDeep
 const generateDelta = require('@wmfs/pg-delta-file')
 const getFunction = require('@wmfs/tymly/lib/getFunction.js')
 
@@ -14,12 +15,18 @@ function loadFunction (env, name) {
 class ExportingCsvDeltaFile {
   init (resourceConfig, env) {
     this.client = env.bootedServices.storage.client
+    this.statebox = env.bootedServices.statebox
+
     this.actionAliases = resourceConfig.actionAliases
     this.createdColumnName = resourceConfig.createdColumnName || '_created'
     this.modifiedColumnName = resourceConfig.modifiedColumnName || '_modified'
     this.csvExtracts = resourceConfig.csvExtracts
+
     this.transformFunction = loadFunction(env, resourceConfig.transformerFunctionName)
     this.filterFunction = loadFunction(env, resourceConfig.filterFunctionName)
+    this.progressFunction = loadFunction(env, resourceConfig.progressFunctionName)
+
+    this.env = env
   }
 
   async run (event, context) {
@@ -33,6 +40,7 @@ class ExportingCsvDeltaFile {
           actionAliases: this.actionAliases,
           transformFunction: this.transformFunction,
           filterFunction: this.filterFunction,
+          progressCallback: this.makeProgressFunction(event, context),
           createdColumnName: this.createdColumnName,
           modifiedColumnName: this.modifiedColumnName,
           csvExtracts: this.csvExtracts,
@@ -51,6 +59,57 @@ class ExportingCsvDeltaFile {
       })
     } // catch
   } // run
+
+  makeProgressFunction (event, context) {
+    if (!event.parentExecutionName) {
+      return this.progressFunction
+    }
+
+    const executionOptions = cloneDeep(context.executionOptions)
+    const formatter = this.makeProgressFormatter(event)
+
+    const pFn = this.progressFunction
+      ? this.progressFunction
+      : () => {}
+
+    return (info, complete) => {
+      try {
+        const updateEvent = complete ? 'sendTaskSuccess' : 'sendTaskHeartbeat'
+        const formattedInfo = formatter(info, complete)
+
+        this.statebox[updateEvent](
+          event.parentExecutionName,
+          formattedInfo,
+          executionOptions
+        )
+
+        pFn(info, complete)
+      } catch (e) {
+        // ignore failures, but don't let them
+        // propagate so we don't bring down the
+        // whole state machine
+      }
+    }
+  } // makeProgressFunction
+
+  makeProgressFormatter (event) {
+    const formatter = event.parentCallbackFormatter
+      ? loadFunction(this.env, event.parentCallbackFormatter)
+      : i => i
+
+    if (!event.parentResultPath) {
+      return formatter
+    }
+
+    return (info, complete) => {
+      const formatted = formatter(cloneDeep(info))
+      formatted.complete = complete
+
+      const shaped = { }
+      dottie.set(shaped, event.parentResultPath, formatted)
+      return shaped
+    }
+  } // makeProgressFormatter
 } // class ExportingCsvDeltaFile
 
 module.exports = ExportingCsvDeltaFile

--- a/lib/components/state-resources/exporting-csv-delta-file/parameters-schema.j2119
+++ b/lib/components/state-resources/exporting-csv-delta-file/parameters-schema.j2119
@@ -1,1 +1,7 @@
-This document specifies a JSON object called a "Config".
+This document specifies a JSON object called a "DeltaExport Parameters".
+A DeltaExport Parameters MAY have a timestamp field named "lastExportDate".
+A DeltaExport Parameters MAY have a string field named "outputFilepath".
+A DeltaExport Parameters MAY have a boolean field named "dryRun".
+A DeltaExport Parameters MAY have a string field named "parentExecutionName".
+A DeltaExport Parameters MAY have a string field named "parentCallbackFormatter".
+A DeltaExport Parameters MAY have a string field named "parentResultPath".

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "lodash": "4.17.15",
     "luxon": "1.19.3",
     "@wmfs/hl-pg-client": "1.13.0",
-    "@wmfs/pg-delta-file": "1.32.1",
+    "@wmfs/pg-delta-file": "1.33.0",
     "@wmfs/pg-diff-sync": "1.15.0",
     "@wmfs/pg-info": "1.13.0",
     "@wmfs/pg-model": "1.17.0",


### PR DESCRIPTION
In addition, if provided with a parent execution name (eg from launch state resource) will automatically send progress heartbeats and then task success to the parent.