### PR TITLE
Move audit log load and format into the audit service

### DIFF
--- a/lib/components/services/audit/index.js
+++ b/lib/components/services/audit/index.js
@@ -112,7 +112,7 @@ function formatLog (log, model, additionalFields) {
     modifiedBy: log.modifiedBy
   }
 
-  additionalFields.forEach(f => formatted[f] = log[f])
+  additionalFields.forEach(f => { formatted[f] = log[f] })
 
   return formatted
 } // fomatLog

--- a/lib/components/services/audit/index.js
+++ b/lib/components/services/audit/index.js
@@ -6,6 +6,7 @@ const schema = require('./schema.json')
 const generateTriggerStatement = require('./generate-trigger-statement')
 const debug = require('debug')('@wmfs/tymly-pg-plugin')
 const pgInfo = require('@wmfs/pg-info')
+const DateTime = require('luxon').DateTime
 
 class AuditService {
   async boot (options) {
@@ -90,7 +91,59 @@ class AuditService {
       }
     })
   } // loadLoads
-}
+
+  formatLogs (modelName, auditLogs) {
+    const model = this.models[modelName.replace('.', '_')]
+
+    const logs = auditLogs
+      .map(l => formatLog(l, model))
+      .reverse()
+    return logs
+  } // formatLogs
+} // AuditService
+
+function formatLog (log, model) {
+  const diffs = formatDiffs(log.diff, model)
+  const when = formatDate(log.modified)
+
+  const formatted = {
+    change: diffs.join(', \n'),
+    modified: when,
+    modifiedBy: log.modifiedBy
+  }
+  return formatted
+} // formatLog
+
+function formatDiffs (diffs, model) {
+  return Object.entries(diffs)
+    .map(([field, change]) => formatDiff(field, change, model))
+    .filter(l => l)
+} // formatDiffs
+
+function formatDiff (field, change, model) {
+  const propertyName = _.camelCase(field)
+  const property = model.properties[propertyName]
+
+  if (!property || property.audit === 'raw') {
+    return
+  }
+
+  const label = property.title || field
+
+  if (!change.from) {
+    return `${label} set to "${change.to}"`
+  }
+  if (!change.to) {
+    return `${label} "${change.from}" was cleared`
+  }
+
+  return `${label} changed from "${change.from}" to "${change.to}"`
+} // formatDiff
+
+function formatDate (jsDate) {
+  const d = DateTime.fromJSDate(jsDate)
+  return `${d.toLocaleString(DateTime.TIME_24_SIMPLE)} ${d.toLocaleString(DateTime.DATE_MED)}`
+} // formatDate
 
 module.exports = {
   schema: schema,

--- a/lib/components/services/audit/index.js
+++ b/lib/components/services/audit/index.js
@@ -11,6 +11,7 @@ class AuditService {
   async boot (options) {
     this.models = options.blueprintComponents.models || {}
     this.client = options.bootedServices.storage.client
+    this.auditLog = options.bootedServices.storage.models.tymly_rewind
     this.schemaNames = options.bootedServices.storage.schemaNames
 
     const pgScripts = options.blueprintComponents.pgScripts || {}
@@ -78,6 +79,17 @@ class AuditService {
     )
     return this.client.query(triggerSQL)
   } // installTrigger
+
+  loadLogs (model, keyObject) {
+    const keyString = Object.values(keyObject).join('_')
+
+    return this.auditLog.find({
+      where: {
+        modelName: { equals: model },
+        keyString: { equals: keyString }
+      }
+    })
+  } // loadLoads
 }
 
 module.exports = {

--- a/lib/components/services/audit/index.js
+++ b/lib/components/services/audit/index.js
@@ -92,17 +92,17 @@ class AuditService {
     })
   } // loadLoads
 
-  formatLogs (modelName, auditLogs) {
+  formatLogs (modelName, auditLogs, additionalFields = []) {
     const model = this.models[modelName.replace('.', '_')]
 
     const logs = auditLogs
-      .map(l => formatLog(l, model))
+      .map(l => formatLog(l, model, additionalFields))
       .reverse()
     return logs
   } // formatLogs
 } // AuditService
 
-function formatLog (log, model) {
+function formatLog (log, model, additionalFields) {
   const diffs = formatDiffs(log.diff, model)
   const when = formatDate(log.modified)
 
@@ -111,8 +111,11 @@ function formatLog (log, model) {
     modified: when,
     modifiedBy: log.modifiedBy
   }
+
+  additionalFields.forEach(f => formatted[f] = log[f])
+
   return formatted
-} // formatLog
+} // fomatLog
 
 function formatDiffs (diffs, model) {
   return Object.entries(diffs)
@@ -141,6 +144,7 @@ function formatDiff (field, change, model) {
 } // formatDiff
 
 function formatDate (jsDate) {
+  if (!jsDate) return undefined
   const d = DateTime.fromJSDate(jsDate)
   return `${d.toLocaleString(DateTime.TIME_24_SIMPLE)} ${d.toLocaleString(DateTime.DATE_MED)}`
 } // formatDate

--- a/lib/components/state-resources/audit-trail/index.js
+++ b/lib/components/state-resources/audit-trail/index.js
@@ -5,18 +5,18 @@ class AuditTrail {
   init (resourceConfig, env) {
     this.auditLog = env.bootedServices.storage.models.tymly_rewind
     this.models = env.blueprintComponents.models
+    this.services = env.bootedServices
   } // init
+
+  get audit () { return this.services.audit }
 
   async run (event, context) {
     const model = event.model
-    const key = Object.values(event.keys).join('_')
 
-    const auditLogs = await this.auditLog.find({
-      where: {
-        modelName: { equals: model },
-        keyString: { equals: key }
-      }
-    })
+    const auditLogs = await this.audit.loadLogs(
+      model,
+      event.keys
+    )
 
     const format = logFormat(event)
 

--- a/lib/components/state-resources/audit-trail/index.js
+++ b/lib/components/state-resources/audit-trail/index.js
@@ -1,10 +1,8 @@
-const _ = require('lodash')
-const DateTime = require('luxon').DateTime
+
+const Readable = 'readable'
 
 class AuditTrail {
   init (resourceConfig, env) {
-    this.auditLog = env.bootedServices.storage.models.tymly_rewind
-    this.models = env.blueprintComponents.models
     this.services = env.bootedServices
   } // init
 
@@ -20,72 +18,16 @@ class AuditTrail {
 
     const format = logFormat(event)
 
-    const logs = formatLogs(
-      format,
-      auditLogs,
-      this.models[model.replace('.', '_')]
-    )
+    const logs = (format === Readable)
+      ? this.audit.formatLogs(model, auditLogs)
+      : auditLogs
 
     context.sendTaskSuccess(logs)
   } // run
 } // class AuditTrail
 
 function logFormat (event) {
-  return event.format || 'readable'
+  return event.format || Readable
 } // logFormat
-
-function formatLogs (format, rawLogs, model) {
-  if (format === 'raw') {
-    return rawLogs
-  }
-
-  const logs = rawLogs
-    .map(l => formatLog(l, model))
-    .reverse()
-  return logs
-} // formattedLogs
-
-function formatLog (log, model) {
-  const diffs = formatDiffs(log.diff, model)
-  const when = formatDate(log.modified)
-
-  const formatted = {
-    change: diffs.join(', \n'),
-    modified: when,
-    modifiedBy: log.modifiedBy
-  }
-  return formatted
-} // formatLog
-
-function formatDiffs (diffs, model) {
-  return Object.entries(diffs)
-    .map(([field, change]) => formatDiff(field, change, model))
-    .filter(l => l)
-} // formatDiffs
-
-function formatDiff (field, change, model) {
-  const propertyName = _.camelCase(field)
-  const property = model.properties[propertyName]
-
-  if (!property || property.audit === 'raw') {
-    return
-  }
-
-  const label = property.title || field
-
-  if (!change.from) {
-    return `${label} set to "${change.to}"`
-  }
-  if (!change.to) {
-    return `${label} "${change.from}" was cleared`
-  }
-
-  return `${label} changed from "${change.from}" to "${change.to}"`
-} // formatDiff
-
-function formatDate (jsDate) {
-  const d = DateTime.fromJSDate(jsDate)
-  return `${d.toLocaleString(DateTime.TIME_24_SIMPLE)} ${d.toLocaleString(DateTime.DATE_MED)}`
-} // formatDate
 
 module.exports = AuditTrail

--- a/test/audit-trail-spec.js
+++ b/test/audit-trail-spec.js
@@ -3,6 +3,7 @@
 const expect = require('chai').expect
 const DateTime = require('luxon').DateTime
 const AuditTrail = require('../lib/components/state-resources/audit-trail')
+const AuditService = require('../lib/components/services/audit').serviceClass
 
 const rawHistory = [
   {
@@ -138,9 +139,15 @@ describe('Audit Trail tests', () => {
             }
           }
         }
-      }
+      },
+      pgScripts: { }
     }
   }
+
+  const auditService = new AuditService()
+  auditService.boot(env)
+  env.bootedServices.audit = auditService
+
   let auditTrail
 
   before(() => {


### PR DESCRIPTION
The audit-trail state-resource was quite fat - it loaded the audit logs directly from the rewind table, and then formatted them into readable diffs. 

I've moved this functionality across into the audit service, so that's accessible from elsewhere within Tymly. The body of the state-resource collapses down into a five lines or so, and that's probably more like what it should have been in the first place :) 