### PR TITLE
fix: Ensure audit logs are ordered most to last recent.

### DIFF
--- a/lib/components/services/audit/index.js
+++ b/lib/components/services/audit/index.js
@@ -81,7 +81,7 @@ class AuditService {
         modelName: { equals: model },
         keyString: { equals: keyString }
       },
-      orderBy: ['-modified']
+      orderBy: ['-created']
     })
   } // loadLoads
 
@@ -90,7 +90,6 @@ class AuditService {
 
     const logs = auditLogs
       .map(l => formatLog(l, model, additionalFields))
-      .reverse()
     return logs
   } // formatLogs
 } // AuditService


### PR DESCRIPTION
Get it right this time - force ordering, don't rearrange in formatLog.