### PR TITLE
feat: 🎸 Add fullExtract parameter to exportingCsvDeltaFile

### DIFF
--- a/lib/components/state-resources/exporting-csv-delta-file/index.js
+++ b/lib/components/state-resources/exporting-csv-delta-file/index.js
@@ -42,16 +42,19 @@ class ExportingCsvDeltaFile {
     try {
       const progressFunction = this.makeProgressFunction(event, context)
 
+      const since = event.fullExtract ? '1970-01-01T00:00:00.000Z' : event.lastExportDate
+      const deleteFn = event.fullExtract ? null : this.deletesFunction
+
       const info = await generateDelta(
         {
           namespace: context.stateMachineMeta.namespace,
           client: this.client,
-          since: event.lastExportDate,
+          since: since,
           outputFilepath: event.outputFilepath,
           actionAliases: this.actionAliases,
           transformFunction: this.transformFunction,
           filterFunction: this.filterFunction,
-          deletesFunction: this.deletesFunction,
+          deletesFunction: deleteFn,
           progressCallback: progressFunction,
           createdColumnName: this.createdColumnName,
           modifiedColumnName: this.modifiedColumnName,


### PR DESCRIPTION
If `event.fullExtract` is true then 
* ignore any `lastExportDate`, insteading setting it to well in the past, so we get all the current records
* ignore any configured `deletesFunction`. For a full export, we want the current state of the tables, soany deletes that might appear in an incremental export SHOULD NOT appear in a full extract.